### PR TITLE
Add support for Intxx and UIntxx to graph widget

### DIFF
--- a/uaclient/graphwidget.py
+++ b/uaclient/graphwidget.py
@@ -29,7 +29,8 @@ class GraphUI(object):
 
     # use tango color schema (public domain)
     colorCycle = ['#4e9a06ff', '#ce5c00ff', '#3465a4ff', '#75507bff', '#cc0000ff', '#edd400ff']
-    acceptedDatatypes = ['Decimal128', 'Double', 'Float', 'Integer', 'UInteger']
+    acceptedDatatypes = ['Decimal128', 'Double', 'Float', 'Integer', 'UInteger', 
+                        'Int16', 'Int32', 'Int64', 'UInt16', 'UInt32', 'UInt64', 'SByte']
 
     def __init__(self, window, uaclient):
         self.window = window


### PR DESCRIPTION
I tried to add a variable to a graph, and it did not work as due to the filter of acceptedDatatypes in graphwidget.py

I got this message in the log;
```
uaclient.graphwidget - INFO - Variable cannot be added to graph because it is of type Int16 or an array')
```

I added the number types avaliable in Prosys Simulation server. I do not know if there might be other types too.

I think this will solve issue #85